### PR TITLE
Removed Azeri/Azerbaijani from RTL list

### DIFF
--- a/public/index.php
+++ b/public/index.php
@@ -225,7 +225,7 @@ include_once('../settings.php');
 =========== RTL START ===========
 */
 
-$rtllist = array("ar-DZ", "ar-EG", "ar", "ary", "az-AZ", "az-LA", "az", "fa", "he-IL", "he");
+$rtllist = array("ar-DZ", "ar-EG", "ar", "ary", "fa", "he-IL", "he");
 
 if (in_array($lang, $rtllist)) {
   $rtl = true;


### PR DESCRIPTION
Azeri language uses the Latin or Turkish alphabet, these are both written from left to right, the only variant is Cyrillic and it's not widely used.